### PR TITLE
fix: revert renaming of `url` option

### DIFF
--- a/lib/nopt.js
+++ b/lib/nopt.js
@@ -4,7 +4,8 @@ var debug = process.env.DEBUG_NOPT || process.env.NOPT_DEBUG
   ? function () { console.error.apply(console, arguments) }
   : function () {}
 
-var path = require("path")
+var url = require('url')
+  , path = require("path")
   , Stream = require("stream").Stream
   , abbrev = require("abbrev")
   , os = require("os")
@@ -25,7 +26,7 @@ exports.clean = clean
 exports.typeDefs =
   { String  : { type: String,  validate: validateString  }
   , Boolean : { type: Boolean, validate: validateBoolean }
-  , URL     : { type: URL,     validate: validateUrl     }
+  , url     : { type: url,     validate: validateUrl     }
   , Number  : { type: Number,  validate: validateNumber  }
   , path    : { type: path,    validate: validatePath    }
   , Stream  : { type: Stream,  validate: validateStream  }


### PR DESCRIPTION
Renaming this option would have required updating it in many places, even outside the pnpm monorepo. Reverting the rename seems to make the tests that failed in the monorepo pass